### PR TITLE
Enable ADB by default when ro.adb.secure is not 1

### DIFF
--- a/tools/post_process_props.py
+++ b/tools/post_process_props.py
@@ -28,9 +28,9 @@ PROP_VALUE_MAX = 91
 # Put the modifications that you need to make into the */build.prop into this
 # function.
 def mangle_build_prop(prop_list):
-  # If ro.debuggable is 1, then enable adb on USB by default
-  # (this is for userdebug builds)
-  if prop_list.get_value("ro.debuggable") == "1":
+  # If ro.adb.secure is not 1, then enable adb on USB by default
+  # (this is for userdebug/eng builds)
+  if prop_list.get_value("ro.adb.secure") != "1":
     val = prop_list.get_value("persist.sys.usb.config")
     if "adb" not in val:
       if val == "":


### PR DESCRIPTION
Change-Id: I33ae5c6f2787017a62e679aa0c28d4b909d45935